### PR TITLE
Bugfix/filter import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.3.1 - 2018-12-08
+------------------
+
+* Fix: import DjangoFilterBackend from django-filters `see django-rest-framework  <https://www.django-rest-framework.org/community/3.5-announcement/#djangofilterbackend>`_
+
+
 0.3.0 - 2018-10-27
 ------------------
 

--- a/didadata/filters.py
+++ b/didadata/filters.py
@@ -35,13 +35,13 @@ class MultipleCharFilter(django_filters.CharFilter):
 
         q = Q()
         for v in set(value.split(',')):
-            q |= Q(**{self.name: v})
+            q |= Q(**{self.field_name: v})
 
         return self.get_method(qs)(q)
 
 
 class RecordFilter(django_filters.FilterSet):
-    metric = MultipleCharFilter(name='metric__name')
+    metric = MultipleCharFilter(field_name='metric__name')
     timestamp = IsoDateTimeRangeFilter()
 
     class Meta:

--- a/didadata/migrations/0001_initial.py
+++ b/didadata/migrations/0001_initial.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('timestamp', models.DateTimeField(auto_now_add=True, db_index=True, verbose_name='Timestamp')),
                 ('value', models.FloatField(verbose_name='Value')),
-                ('metric', models.ForeignKey(verbose_name='Metric', to='didadata.Metric', on_delete=models.PROTECT)),
+                ('metric', models.ForeignKey(verbose_name='Metric', to='didadata.Metric', on_delete=models.deletion.CASCADE)),
             ],
             options={
                 'verbose_name_plural': 'Records',

--- a/didadata/migrations/0001_initial.py
+++ b/didadata/migrations/0001_initial.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('timestamp', models.DateTimeField(auto_now_add=True, db_index=True, verbose_name='Timestamp')),
                 ('value', models.FloatField(verbose_name='Value')),
-                ('metric', models.ForeignKey(verbose_name='Metric', to='didadata.Metric', on_delete=models.deletion.CASCADE)),
+                ('metric', models.ForeignKey(verbose_name='Metric', to='didadata.Metric', on_delete=models.PROTECT)),
             ],
             options={
                 'verbose_name_plural': 'Records',

--- a/didadata/serializers.py
+++ b/didadata/serializers.py
@@ -7,6 +7,7 @@ class MetricSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Metric
+        fields = '__all__'
 
 
 class MinimalRecordSerializer(serializers.ModelSerializer):

--- a/didadata/viewsets.py
+++ b/didadata/viewsets.py
@@ -1,4 +1,5 @@
-from rest_framework import filters, mixins, permissions, viewsets
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import mixins, permissions, viewsets
 
 from .filters import RecordFilter
 from .models import Metric, Record
@@ -24,7 +25,7 @@ class RecordViewSet(
 ):
     queryset = Record.objects.all()
     permission_classes = (permissions.DjangoModelPermissions,)
-    filter_backends = (filters.DjangoFilterBackend,)
+    filter_backends = (DjangoFilterBackend,)
     filter_class = RecordFilter
 
     def get_queryset(self):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages, setup
 
 
-version = '0.3.0'
+version = '0.3.1'
 
 
 if sys.argv[-1] == 'publish':


### PR DESCRIPTION
This pr fixes the import of the DjangoFilterBackend. In older versions we imported the filter backend from rest_framework filters
`from rest_framework import filters`

This changed with the latest version and it is imported from django filters
`from django_filters.rest_framework import DjangoFilterBackend`