### PR TITLE
show metric name instead of metric id in admin

### DIFF
--- a/didadata/admin.py
+++ b/didadata/admin.py
@@ -10,6 +10,6 @@ class MetricAdmin(admin.ModelAdmin):
 
 @admin.register(Record)
 class RecordAdmin(admin.ModelAdmin):
-    list_display = ('metric_id', 'timestamp', 'value')
+    list_display = ('metric__name', 'timestamp', 'value')
     list_filter = ('metric',)
     date_hierarchy = 'timestamp'

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -18,7 +18,7 @@ class TestRecordAdmin:
 
     def test_list_display(self, rf):
         modeladmin = RecordAdmin(Record, admin.site)
-        assert modeladmin.list_display == ('metric_id', 'timestamp', 'value')
+        assert modeladmin.list_display == ('metric__name', 'timestamp', 'value')
 
     def test_list_filter(self, rf):
         modeladmin = RecordAdmin(Record, admin.site)


### PR DESCRIPTION
Hy @stephrdev 

ich changed metric_id to metric__name in admin. I think more human readable is better than metric id:

<img width="422" alt="screen shot 2019-02-14 at 21 36 55" src="https://user-images.githubusercontent.com/847875/52816143-f08a3200-30a0-11e9-94b8-94b763daeee0.png">
