### PR TITLE
prepare for version 0.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+0.4.0 - 2020-03-30
+------------------
+
+* add django 2.2.x support
+* add python 3.8.x support
+* improve tests: switch from travis to github actions
+* add workflow to push package to pypi easily
+
+
 0.3.3 - 2019-02-14
 ------------------
 

--- a/didadata/__init__.py
+++ b/didadata/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.3.3'
+__version__ = '0.4.0'
 default_app_config = 'didadata.apps.DidadataConfig'


### PR DESCRIPTION
I prepared didadata for a new release that includes python 3.8 and django 2.2 support.

There is also a github workflow to publish it to pypi. If this PR is merged into master go to your project settings and add two new secrets envs https://github.com/stephrdev/django-didadata/settings/secrets:
- PYPI_USERNAME
- PYPI_PASSWORD
You have to set your pypi username and password. After that execute the make command
`make release-tag`

If the new tag is pushed to github, then (at github.com) go to https://github.com/stephrdev/django-didadata/releases/new choose the new tag and click `publish release`

that´s it